### PR TITLE
make uninstalling collective.opengraph possible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(name='collective.opengraph',
       install_requires=[
           'setuptools',
           'ordereddict',
+          'plone.api',
           # -*- Extra requirements: -*-
       ],
       extras_require=dict(test=tests_require),

--- a/src/collective/opengraph/browser.py
+++ b/src/collective/opengraph/browser.py
@@ -1,6 +1,6 @@
 from zope.interface import alsoProvides
 from zope.interface import noLongerProvides
-from zope.site.hooks import getSite
+from zope.component.hooks import getSite
 from zope.event import notify
 
 from Products.Five import BrowserView

--- a/src/collective/opengraph/configure.zcml
+++ b/src/collective/opengraph/configure.zcml
@@ -19,6 +19,21 @@
     provides="Products.GenericSetup.interfaces.EXTENSION"
     />
 
+  <genericsetup:registerProfile
+    name="uninstall"
+    title="Uninstall Collective Opengraph"
+    directory="profiles/uninstall"
+    description="Un-Installs the collective.opengraph package"
+    provides="Products.GenericSetup.interfaces.EXTENSION"
+    />
+  
+  <genericsetup:importStep
+      name="collective.opengraph.uninstall"
+      title="collective.opengraph: uninstall steps"
+      description="Various uninstall steps that are not handled by GS import/export handlers."
+      handler="collective.opengraph.setuphandlers.uninstall" />
+
+
   <browser:resource
     name="collectiveopengraph.png"
     image="facebook.png"

--- a/src/collective/opengraph/profiles/uninstall/actions.xml
+++ b/src/collective/opengraph/profiles/uninstall/actions.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<object name="portal_actions" meta_type="Plone Actions Tool"
+   xmlns:i18n="http://xml.zope.org/namespaces/i18n">
+ <object name="object_buttons" meta_type="CMF Action Category">
+  <object name="enable_opengraph" meta_type="CMF Action"
+          i18n:domain="collective.opengraph"
+          remove="True">
+  </object>
+  <object name="disable_opengraph" meta_type="CMF Action"
+          i18n:domain="collective.opengraph"
+          remove="True">
+  </object>
+ </object>
+</object>

--- a/src/collective/opengraph/profiles/uninstall/browserlayer.xml
+++ b/src/collective/opengraph/profiles/uninstall/browserlayer.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<layers>
+    <layer name="collective.opengraph" 
+           interface="collective.opengraph.interfaces.IBrowserLayer"
+           remove="True"/>
+</layers>
+

--- a/src/collective/opengraph/profiles/uninstall/componentregistry.xml
+++ b/src/collective/opengraph/profiles/uninstall/componentregistry.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<componentregistry>
+ <adapters/>
+ <utilities>
+  <utility
+     interface="collective.opengraph.interfaces.IOpengraphMarkerUtility"
+     factory="collective.opengraph.utils.OpengraphMarkerUtility"
+     remove="True" />
+ </utilities>
+</componentregistry>

--- a/src/collective/opengraph/profiles/uninstall/controlpanel.xml
+++ b/src/collective/opengraph/profiles/uninstall/controlpanel.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<object name="portal_controlpanel">
+ <configlet title="Collective Opengraph" action_id="collective.geo.opengraph"
+            appId="collective.geo.opengraph" category="Products" condition_expr=""
+            url_expr="string:$portal_url/@@collectiveopengraph-controlpanel"
+            icon_expr="string:$portal_url/++resource++collectiveopengraph.png"
+            visible="True"
+            remove="True">
+     <permission>Manage portal</permission>
+ </configlet>
+</object>

--- a/src/collective/opengraph/profiles/uninstall/metadata.xml
+++ b/src/collective/opengraph/profiles/uninstall/metadata.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<metadata>
+  <version>0.1</version>
+  <dependencies>
+      <dependency>profile-plone.app.registry:default</dependency>
+  </dependencies>
+</metadata>

--- a/src/collective/opengraph/profiles/uninstall/registry.xml
+++ b/src/collective/opengraph/profiles/uninstall/registry.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<registry>
+  <records interface="collective.opengraph.interfaces.IOpengraphSettings"
+           remove="True" />
+</registry>

--- a/src/collective/opengraph/setuphandlers.py
+++ b/src/collective/opengraph/setuphandlers.py
@@ -1,0 +1,47 @@
+import logging
+from plone import api
+import transaction
+from zope import interface
+from zope.component.interfaces import ComponentLookupError
+
+from collective.opengraph.interfaces import IOpengraphable, IOpengraphMarker
+from collective.opengraph.interfaces import IOpengraphMarkerUtility
+
+log = logging.getLogger(__name__)
+
+
+def uninstall(context):
+    marker = 'collective.opengraph_uninstall.txt'
+    if context.readDataFile(marker) is None:
+        return
+
+    query = {'object_provides':
+             'collective.opengraph.interfaces.IOpengraphable'}
+    catalog = api.portal.get_tool('portal_catalog')
+    res = catalog(query)
+    log.info("Removing interfaces from %s objects", len(res))
+    for item in res:
+        ob = item.getObject()
+        interface.directlyProvides(
+            ob,
+            interface.directlyProvidedBy(ob)-IOpengraphable-IOpengraphMarker)
+        ob.reindexObject(idxs=['object_provides'])
+    log.info("Unregistering utility")
+    portal = api.portal.get()
+    sm = portal.getSiteManager()
+    try:
+        util = sm.getUtility(IOpengraphMarkerUtility)
+        del util
+    except ComponentLookupError:
+        pass
+    sm.unregisterUtility(provided=IOpengraphMarkerUtility)
+    sm.utilities.unsubscribe((), IOpengraphMarkerUtility)
+    try:
+        del sm.utilities.__dict__['_provided'][IOpengraphMarkerUtility]
+    except KeyError:
+        # already removed
+        pass
+
+    log.info("Committing transaction...")
+    transaction.commit()
+    log.info("done.")

--- a/src/collective/opengraph/viewlets.py
+++ b/src/collective/opengraph/viewlets.py
@@ -3,8 +3,7 @@ from zope.component import getMultiAdapter
 from Acquisition import aq_inner
 from zope.interface import implements
 from zope.component import getUtility
-from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
-
+from zope.browserpage.viewpagetemplatefile import ViewPageTemplateFile
 from ordereddict import OrderedDict
 
 from plone.app.layout.viewlets import ViewletBase


### PR DESCRIPTION
I need to remove collective.opengraph from a Plone4 site, to prepare for Plone5 upgrade. This is what it takes to make that possible.